### PR TITLE
Update version of Black dependency

### DIFF
--- a/{{cookiecutter.repo_name}}/Pipfile
+++ b/{{cookiecutter.repo_name}}/Pipfile
@@ -9,7 +9,7 @@ python_version = "{python_version}"
 [packages]
 
 [dev-packages]
-black = "==19.3b0"
+black = "==20.8b1"
 flake8 = "*"
 isort = "*"
 mypy = "*"


### PR DESCRIPTION
(since black is still marked as pre-release, need to pin down the exact version, 20.8b1 is currently the latest)